### PR TITLE
replace tensorboardX dependency

### DIFF
--- a/rvt/utils/rvt_utils.py
+++ b/rvt/utils/rvt_utils.py
@@ -12,7 +12,7 @@ import signal
 from datetime import datetime
 
 import torch
-import tensorboardX
+from torch.utils.tensorboard import SummaryWriter
 
 from torch.nn.parallel import DistributedDataParallel as DDP
 
@@ -87,7 +87,7 @@ def count_parameters(model):
 
 class TensorboardManager:
     def __init__(self, path):
-        self.writer = tensorboardX.SummaryWriter(path)
+        self.writer = SummaryWriter(path)
 
     def update(self, split, step, vals):
         for k, v in vals.items():

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ requirements = [
     "scipy",
     "einops",
     "pyrender",
-    "tensorboardX",
     "transformers",
     "omegaconf",
     "natsort",


### PR DESCRIPTION
The tensorboardX dependency seems unnecessary as `SummaryWriter` is available in `torch.utils.tensorboard`