### PR TITLE
fix import for mvt package

### DIFF
--- a/rvt/eval.py
+++ b/rvt/eval.py
@@ -25,11 +25,11 @@ from yarr.utils.stat_accumulator import SimpleAccumulator
 from yarr.utils.log_writer import LogWriter
 from yarr.agents.agent import VideoSummary
 
-import mvt.config as default_mvt_cfg
+import rvt.mvt.config as default_mvt_cfg
 import rvt.models.rvt_agent as rvt_agent
 import rvt.config as default_exp_cfg
 
-from mvt import MVT
+from rvt.mvt.mvt import MVT
 from rvt.libs.peract.helpers import utils
 from rvt.utils.custom_rlbench_env import (
     CustomMultiTaskRLBenchEnv2 as CustomMultiTaskRLBenchEnv,

--- a/rvt/models/rvt_agent.py
+++ b/rvt/models/rvt_agent.py
@@ -15,10 +15,10 @@ from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.optim.lr_scheduler import CosineAnnealingLR
 
 import rvt.utils.peract_utils as peract_utils
-import mvt.utils as mvt_utils
+import rvt.mvt.utils as mvt_utils
 import rvt.utils.rvt_utils as rvt_utils
 import peract_colab.arm.utils as arm_utils
-from mvt.augmentation import apply_se3_aug_con, aug_utils
+from rvt.mvt.augmentation import apply_se3_aug_con, aug_utils
 from peract_colab.arm.optim.lamb import Lamb
 from yarr.agents.agent import ActResult
 from rvt.utils.dataset import _clip_encode_text

--- a/rvt/mvt/__init__.py
+++ b/rvt/mvt/__init__.py
@@ -2,4 +2,3 @@
 #
 # Licensed under the NVIDIA Source Code License [see LICENSE for details].
 
-from .mvt import MVT

--- a/rvt/mvt/augmentation.py
+++ b/rvt/mvt/augmentation.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import torch
-import mvt.aug_utils as aug_utils
+import rvt.mvt.aug_utils as aug_utils
 from pytorch3d import transforms as torch3d_tf
 from scipy.spatial.transform import Rotation
 

--- a/rvt/mvt/mvt.py
+++ b/rvt/mvt/mvt.py
@@ -7,11 +7,11 @@ import torch
 
 from torch import nn
 
-import mvt.utils as mvt_utils
+import rvt.mvt.utils as mvt_utils
 
-from mvt.mvt_single import MVT as MVTSingle
-from mvt.config import get_cfg_defaults
-from mvt.renderer import BoxRenderer
+from rvt.mvt.mvt_single import MVT as MVTSingle
+from rvt.mvt.config import get_cfg_defaults
+from rvt.mvt.renderer import BoxRenderer
 
 
 class MVT(nn.Module):

--- a/rvt/mvt/mvt_single.py
+++ b/rvt/mvt/mvt_single.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 from torch import nn
 from einops import rearrange, repeat
 
-from mvt.attn import (
+from rvt.mvt.attn import (
     Conv2DBlock,
     Conv2DUpsampleBlock,
     PreNorm,

--- a/rvt/train.py
+++ b/rvt/train.py
@@ -20,9 +20,9 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 import config as exp_cfg_mod
 import rvt.models.rvt_agent as rvt_agent
 import rvt.utils.ddp_utils as ddp_utils
-import mvt.config as mvt_cfg_mod
+import rvt.mvt.config as mvt_cfg_mod
 
-from mvt import MVT
+from rvt.mvt.mvt import MVT
 from rvt.models.rvt_agent import print_eval_log, print_loss_log
 from rvt.utils.get_dataset import get_dataset
 from rvt.utils.rvt_utils import (


### PR DESCRIPTION
`setup.py` defines only the rvt package. Since mvt is a subfolder of rvt imports should start with 'rvt'.  This MR allows me to use RVT in other projects. Alternative to MR #14

